### PR TITLE
Add node: true to jsgreat.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,6 +7,7 @@
   "unused": "vars",
   "strict": true,
   "trailing": true,
+  "node": true,
   "globals": {
     "module": true,
     "require": true,


### PR DESCRIPTION
This allows consumers using CommonJS style packaging systems (AKA Yola) to lint their code using jsgreat.
