### PR TITLE
Allow expressions in javascript code

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -8,6 +8,7 @@
   "strict": true,
   "trailing": true,
   "node": true,
+  "expr": true,
   "globals": {
     "module": true,
     "require": true,


### PR DESCRIPTION
This allows expressions in our javascript code.

This is useful for testing when we may want to do assert something like this:

``` javascript
variable.should.be.undefined;
```

or

``` javascript
$element.should.be.visisble;
```
