### PR TITLE
Add “before” to jshintrc file

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,6 +21,7 @@
     "gettext": true,
     "describe": true,
     "it": true,
+    "before": true,
     "beforeEach": true,
     "afterEach": true,
     "expect": true,


### PR DESCRIPTION
We had beforeEach for running before each test. This adds “before” for a single run before all tests.
