### PR TITLE
Add `after` as a global

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,6 +23,7 @@
     "it": true,
     "before": true,
     "beforeEach": true,
+    "after": true,
     "afterEach": true,
     "expect": true,
     "spyOn": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsgreat",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Yola's guide to writing JS great.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds `after` as a supported global.

Makes it nice for sublime, but also prevents Snitch commenting on correct code.