### PR TITLE
Add module option

### DIFF
--- a/es6/.jshintrc
+++ b/es6/.jshintrc
@@ -1,4 +1,5 @@
 {
   "extends": "../.jshintrc",
-  "esnext": true
+  "esnext": true,
+  "module": true
 }


### PR DESCRIPTION
Instructs JSHint to lint files as ES6 modules. This currently enables strict mode linting without the use of `"use strict";`.

See https://github.com/jshint/jshint/commit/290280c