### PR TITLE
Add eqnull option to jshint config

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,7 @@
 {
   "curly": true,
   "eqeqeq": true,
+  "eqnull": true,
   "expr": true,
   "latedef": true,
   "maxlen": 80,


### PR DESCRIPTION
> http://jshint.com/docs/options/#eqnull
This option suppresses warnings about == null comparisons. Such comparisons are often useful when you want to check if a variable is null or undefined.